### PR TITLE
Added a fix for throwing exceptions on 200 codes

### DIFF
--- a/src/Services/InternalRequestService.php
+++ b/src/Services/InternalRequestService.php
@@ -75,8 +75,14 @@ final class InternalRequestService
     {
         $response = App::handle($request);
 
-        if ($response->getStatusCode() !== Response::HTTP_OK) {
-            throw new HttpException($response->getStatusCode(), (string) $response->getContent());
+        if ($response->getStatusCode() < 200 || $response->getStatusCode() >= 300) {
+            throw new HttpException(
+                $response->getStatusCode(),
+                $response->getContent() ?: Response::$statusTexts[$response->getStatusCode()] ?? 'Unknown error',
+                null,
+                [],
+                $response->getStatusCode(),
+            );
         }
 
         return $response;

--- a/tests/InternalRequestServiceTest.php
+++ b/tests/InternalRequestServiceTest.php
@@ -9,6 +9,7 @@ use Faker\Generator;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use TheZombieGuy\InternalRequest\Exceptions\RouteNotFoundInternalRequestException;
 use TheZombieGuy\InternalRequest\Services\InternalRequestService;
 
@@ -147,5 +148,59 @@ class InternalRequestServiceTest extends TestCase
 
         // Call the request method with a non-existent route
         $service->request('non.existent.route', 'GET');
+    }
+
+    public function testAllowsSuccessfulHttpStatusCodes(): void
+    {
+        Route::get('success-test', static function () {
+            return response('', 201); // Created
+        })->name('success.route');
+
+        $service = new InternalRequestService();
+
+        $response = $service->request('success.route', 'GET');
+
+        $this->assertEquals(201, $response->getStatusCode());
+    }
+
+    public function testAllowsSuccessfulHttpStatusCodesWithNoContent(): void
+    {
+        Route::get('no-content-test', static function () {
+            return response()->noContent() ;// Created
+        })->name('no-content.route');
+
+        $service = new InternalRequestService();
+
+        $response = $service->request('no-content.route', 'GET');
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    public function testThrowsExceptionForClientErrors(): void
+    {
+        Route::get('client-error-test', static function () {
+            return response('Not Found', 404); // Client error
+        })->name('client.error.route');
+
+        $service = new InternalRequestService();
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionCode(404);
+
+        $service->request('client.error.route', 'GET');
+    }
+
+    public function testThrowsExceptionForServerErrors(): void
+    {
+        Route::get('server-error-test', static function () {
+            return response('Internal Server Error', 500); // Server error
+        })->name('server.error.route');
+
+        $service = new InternalRequestService();
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionCode(500);
+
+        $service->request('server.error.route', 'GET');
     }
 }


### PR DESCRIPTION
Added

- Support for Non-200 Success Status Codes: The call method now accepts all successful HTTP status codes (200–299) without throwing an exception.
- Explicit Exception Code Handling: Updated the HttpException thrown by the call method to set the HTTP status code as the exception's internal code for better compatibility with test assertions.

Fixed

- Test Failures for Exception Codes: Resolved an issue where tests for client (4xx) and server (5xx) error responses failed due to the HttpException not having the expected exception code.

Tests

- New Test for Successful HTTP Status Codes: Added a test to ensure that responses with status codes like 201 or 204 are handled correctly.
- New Test for Client Errors: Added a test to validate that client error responses (e.g., 404) throw an HttpException with the correct status code.
- New Test for Server Errors: Added a test to validate that server error responses (e.g., 500) throw an HttpException with the correct status code.